### PR TITLE
Implement NGramDatastore include-all option

### DIFF
--- a/ngram_datastore/build.py
+++ b/ngram_datastore/build.py
@@ -8,14 +8,16 @@ from ngram_datastore.ngram_datastore import NGramDatastoreBuilder
 @click.option("--model-path", type=str, default="lmsys/vicuna-7b-v1.5")
 @click.option("--dataset-name", type=str, default="Aeala/ShareGPT_Vicuna_unfiltered")
 @click.option("--datastore-path", type=str, default="./datastore/datastore_chat_small.idx")
-@click.option("--ngram-n", "-n", type=int, default=3)
-@click.option("--num-conversations", "-c", type=int, default=10)
-@click.option("--num-top-ngrams", "-t", type=int, default=10)
-def main(model_path: str, dataset_name: str, datastore_path: str, ngram_n: int, num_conversations: int, num_top_ngrams: int):
+@click.option("--ngram-n", "-n", type=int, default=3)               # number of ngrams to build the datastore on
+@click.option('--include-all', '-a', is_flag=True)                  # includes all ngrams up to ngram_n. Specify either num_top_ngrams or merge_ratio for keeping only a few when merging
+@click.option("--num-conversations", "-c", type=int, default=10)    # number of conversations to build the datstore
+@click.option("--num-top-ngrams", "-t", type=int, default=10)       # for keeping in the datastore
+@click.option('--merge-ratio', '-r',type=float, default=0.0)        # merge ratio. If not specified, merging defaults to choosing top N
+def main(model_path: str, dataset_name: str, datastore_path: str, ngram_n: int, num_conversations: int, num_top_ngrams: int, include_all: bool, merge_ratio: float):
     reader = draftretriever.Reader(
         index_file_path=datastore_path,
     )
-    datastore_builder = NGramDatastoreBuilder(dataset_name, num_conversations, model_path, reader, ngram_n, num_top_ngrams)
+    datastore_builder = NGramDatastoreBuilder(dataset_name, num_conversations, model_path, reader, ngram_n, num_top_ngrams, include_all, merge_ratio)
     datastore = datastore_builder.load_or_build()
 
 if __name__ == '__main__':

--- a/ngram_datastore/ngram_datastore.py
+++ b/ngram_datastore/ngram_datastore.py
@@ -15,7 +15,11 @@ class NGramDatastore:
 
     def search(self, ngram):
         '''Can return either None or a tree'''
-        return self.get(ngram)
+        for i in range(len(ngram)):
+            tree = self.get(ngram[i:])
+            if tree is not None:
+                return tree
+        return None
     
     def get(self, ngram):
         '''Can return either None or a tree'''
@@ -28,17 +32,30 @@ class NGramDatastore:
 class NGramDatastoreBuilder:
     EXTENSION = 'pkl'
 
-    def __init__(self, dataset_name: str, num_conversations: int, model_path: str, reader: Reader, ngram_n: int, num_top_ngrams: int) -> None:
+    def __init__(self, dataset_name: str, num_conversations: int, model_path: str, reader: Reader, 
+                 ngram_n: int, num_top_ngrams: int, include_all: bool, merge_ratio: float) -> None:
         self.dataset_name = dataset_name
         self.num_conversations = num_conversations
         self.reader = reader
         self.model_path = model_path
         self.ngram_n = ngram_n
         self.num_top_ngrams = num_top_ngrams
+        self.merge_ratio = merge_ratio
+        discard_tag = f"-merge{merge_ratio}" if merge_ratio != 0.0 else f"-top{num_top_ngrams}"
+        self.include_all = include_all
+        include_all_tag = "-include-all" if include_all else ""
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_path)
         self.datastore_dpath = Path("./ngram_datastore/built_datastores/")
-        self.datastore_path = self.datastore_dpath / f"{NGramDatastoreBuilder.get_abbr_dataset_name(dataset_name)}-n{self.ngram_n}-convs{num_conversations}-top{num_top_ngrams}.{NGramDatastoreBuilder.EXTENSION}"
-        self.top0_backing_datastore_path = self.datastore_dpath / f"{NGramDatastoreBuilder.get_abbr_dataset_name(dataset_name)}-n{self.ngram_n}-convs{num_conversations}-top0.{NGramDatastoreBuilder.EXTENSION}"
+        self.datastore_path = self.datastore_dpath / f"{NGramDatastoreBuilder.get_abbr_dataset_name(dataset_name)}-n{self.ngram_n}{include_all_tag}-convs{num_conversations}{discard_tag}.{NGramDatastoreBuilder.EXTENSION}"
+        self.top0_backing_datastore_path = {}   # a dict of backing paths for include-all option
+        if include_all:
+            for ngram in range(1, ngram_n+1):
+                path = self.datastore_dpath / f"{NGramDatastoreBuilder.get_abbr_dataset_name(dataset_name)}-n{ngram}-convs{num_conversations}-top0.{NGramDatastoreBuilder.EXTENSION}"
+                self.top0_backing_datastore_path[ngram] = path
+        else:
+            path = self.datastore_dpath / f"{NGramDatastoreBuilder.get_abbr_dataset_name(dataset_name)}-n{self.ngram_n}-convs{num_conversations}-top0.{NGramDatastoreBuilder.EXTENSION}"
+            self.top0_backing_datastore_path[self.ngram_n] = path
+
         os.makedirs(self.datastore_dpath, exist_ok=True)
 
     @staticmethod
@@ -48,35 +65,56 @@ class NGramDatastoreBuilder:
         else:
             raise AssertionError
 
-    def build(self) -> NGramDatastore:
-        datastore = NGramDatastore()
-
+    def get_ngrams_from_dataset(self, num_ngram: int):
         if self.dataset_name == "Aeala/ShareGPT_Vicuna_unfiltered":
-            ngrams = get_ngrams_from_sharegpt(self.tokenizer, self.dataset_name, self.ngram_n, self.num_conversations, self.num_top_ngrams)
+            ngrams = get_ngrams_from_sharegpt(self.tokenizer, self.dataset_name, num_ngram, self.num_conversations, self.num_top_ngrams, self.merge_ratio)
         elif self.dataset_name == "bigcode/the-stack":
             raise AssertionError()
         else:
             print("We only support Aeala/ShareGPT_Vicuna_unfiltered or bigcode/the-stack datasets for now")
             quit()
+        return ngrams
+    
 
-        if self.top0_backing_datastore_path.exists():
-            print(f"Building with backing datastore {self.top0_backing_datastore_path}")
-            top0_backing_datastore = NGramDatastoreBuilder.load(self.top0_backing_datastore_path)
+    def get_backing_datastore(self, path: str):
+        if path.exists():
+            print(f"Building with backing datastore {path}")
+            top0_backing_datastore = NGramDatastoreBuilder.load(path)
         else:
             print(f"Building with reader")
             top0_backing_datastore = None
+        return top0_backing_datastore
 
-        for ngram in tqdm(ngrams):
-            # The backing datastore is equivalent to the reader and is much faster to query
-            if top0_backing_datastore != None:
-                tree = top0_backing_datastore[ngram]
-            else:
-                tree = self.reader.search(list(ngram))
-            datastore.insert(ngram, tree)
+
+    def build(self) -> NGramDatastore:
+        datastore = NGramDatastore()
+
+        if self.include_all:
+            for num_ngram in range(1, self.ngram_n+1):
+                ngrams = self.get_ngrams_from_dataset(num_ngram)
+                top0_backing_datastore = self.get_backing_datastore(self.top0_backing_datastore_path[num_ngram])
+                for ngram in tqdm(ngrams):
+                    # The backing datastore is equivalent to the reader and is much faster to query
+                    if top0_backing_datastore != None:
+                        tree = top0_backing_datastore.get(ngram)
+                    else:
+                        tree = self.reader.search(list(ngram))
+                    datastore.insert(ngram, tree)
+        else:
+            ngrams = self.get_ngrams_from_dataset(self.ngram_n)
+            top0_backing_datastore = self.get_backing_datastore(self.top0_backing_datastore_path[self.ngram_n])
+            for ngram in tqdm(ngrams):
+                # The backing datastore is equivalent to the reader and is much faster to query
+                if top0_backing_datastore != None:
+                    tree = top0_backing_datastore[ngram]
+                else:
+                    tree = self.reader.search(list(ngram))
+                datastore.insert(ngram, tree)
 
         with open(self.datastore_path, 'wb') as f:
             pickle.dump(datastore, f)
     
+
     def load_or_build(self) -> NGramDatastore:
         if os.path.exists(self.datastore_path):
             start_time = time.time()
@@ -92,6 +130,6 @@ class NGramDatastoreBuilder:
         return datastore
     
     @staticmethod
-    def load(datastore_path: str) -> dict:
+    def load(datastore_path: str) -> NGramDatastore:
         with open(datastore_path, 'rb') as f:
             return pickle.load(f)

--- a/ngram_datastore/utils.py
+++ b/ngram_datastore/utils.py
@@ -5,10 +5,12 @@ from tqdm import tqdm
 from itertools import islice
 from collections import defaultdict
 
-def get_ngrams_from_sharegpt(tokenizer: PreTrainedTokenizer, dataset_name: str, ngram_n: int, num_conversations: int, num_top_ngrams: int) -> Set[Tuple[str]]:
+
+# returns ngrams with specifically ngram_n number of ngrams
+def get_ngrams_from_sharegpt(tokenizer: PreTrainedTokenizer, dataset_name: str, ngram_n: int, num_conversations: int, num_top_ngrams: int, merge_ratio: float) -> Set[Tuple[str]]:
     all_ngram_counts = defaultdict(int)
     dataset = load_dataset(dataset_name, split='train')
-    
+
     dataset_it = dataset if num_conversations == 0 else islice(dataset, num_conversations)
 
     for conversations in tqdm(dataset_it):
@@ -21,7 +23,13 @@ def get_ngrams_from_sharegpt(tokenizer: PreTrainedTokenizer, dataset_name: str, 
 
     sorted_ngram_counts = sorted(all_ngram_counts.items(), key=(lambda item : (-item[1], item[0])))
     sorted_ngrams = [ngram for ngram, _ in sorted_ngram_counts]
-    top_ngrams = sorted_ngrams if num_top_ngrams == 0 else sorted_ngrams[:num_top_ngrams]
+
+    if merge_ratio != 0.0:
+        top_ngrams = sorted_ngrams[:int(len(sorted_ngrams) * merge_ratio)]
+    elif num_top_ngrams != 0:
+        top_ngrams = sorted_ngrams[:num_top_ngrams]
+    else:
+        top_ngrams = sorted_ngrams
     return top_ngrams
 
 def get_ngrams_from_list(l: List[str], ngram_n: int) -> Set[Tuple[str]]:


### PR DESCRIPTION
`--include-all` option, when asserted, builds (or loads) a datastore including all ngrams up to (and including) `ngram_n` by merging each n-gram datastore.

the `merge_ratio` can be defined (between 0 and 1) to decide what percentage of top `merge_ratio` ngrams you want to merger from each n-gram datastore.
If not specified, merge is done by choosing `num_top_ngrams` from each n-gram datastore.